### PR TITLE
Import usage from Particular site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@ NServiceBus.Gateway.Channels.HttpVNext
 ===================
 An HTTP channel implementation for NServiceBus.Gateway that doesn't use HTTP Headers for message content or metadata. As such it should be easier to use this channel where headers may be modified (e.g. when a gateway is behind a reverse proxy such as NGINX).
 
+## Usage
+
+To use this channel, install the NuGet package and configure the gateway to use it when receiving messages:
+
+```
+var gatewayConfig = endpointConfiguration.Gateway();
+gatewayConfig.ChannelFactories(s => new HttpVNextChannelSender(), r => new HttpVNextChannelReceiver());
+
+gatewayConfig.AddReceiveChannel("http://Headquarter.mycorp.com/", "httpVNext");
+```
+
+The final step is to configure the gateway to use the new channel when transmitting messages:
+
+```
+var gatewayConfig = endpointConfiguration.Gateway();
+gatewayConfig.ChannelFactories(s => new HttpVNextChannelSender(), r => new HttpVNextChannelReceiver());
+
+gatewayConfig.AddSite("SiteA", "http://SiteA.mycorp.com");
+
+```
+
+## Licenses
+
 ### [SimpleJson](https://github.com/facebook-csharp-sdk/simple-json/) 
 
 SimpleJson is licensed under the MIT license as described [here](https://github.com/facebook-csharp-sdk/simple-json/blob/master/LICENSE.txt).


### PR DESCRIPTION
Hi @welshdave!

At Particular we are needing to more clearly delineate our supported packages and community contributions. And we realize that our docs engine is difficult for anyone to use who doesn't work for the company, and that community packages are best documented in their home repo and linked to from Particular's site when appropriate.

So in https://github.com/Particular/docs.particular.net/pull/5053 we are creating a better-curated community extensions page that, being only Markdown, is much easier to contribute to. We had a small page, which wasn't even included in the nav, which had some usage documentation for the library. This PR takes [that content](https://github.com/Particular/docs.particular.net/pull/5053/commits/6ddf45e431caed47dc261d6cd37547d27642b3a9#diff-63f19f4d9d76c88352f48f05b5f8f56f) and adds it to your readme.

In addition to the [listing on the community page](https://github.com/Particular/docs.particular.net/pull/5053/commits/0cbbec6268c949eec522789c46b232bca5e406a5#diff-dbf79fbda390c58c59f24506e53cc68a) we're also [linking directly from the Gateway page](https://github.com/Particular/docs.particular.net/pull/5053/commits/6b053e8ddc747b097d06f2d2c6d513c1b5631a1d) which should provide better visibility than existed before.